### PR TITLE
drop ruby 2.5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        ruby: [ '2.5', '2.6', '2.7', '3.0', '3.1' ]
+        ruby: [ '2.6', '2.7', '3.0', '3.1' ]
 
     runs-on: ${{ matrix.os }}
 

--- a/embed_callbacks.gemspec
+++ b/embed_callbacks.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.description   = %q{Whenever you want to add a callback, you can easily incorporate the process.\n }
   spec.homepage      = "https://github.com/hotoolong/embed_callbacks"
   spec.license       = "MIT"
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.5.0")
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.6.0")
 
   spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }

--- a/lib/embed_callbacks/version.rb
+++ b/lib/embed_callbacks/version.rb
@@ -1,3 +1,3 @@
 module EmbedCallbacks
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end


### PR DESCRIPTION
Droped Ruby 2.5 because Ruby 2.5 is no longer supported by rubygems.